### PR TITLE
fix: cpx build; adding simple quotes in build directories path

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -32,7 +32,7 @@ module.exports = {
                 hidden: true
             },
             scripts: "webpack --config ./webpack.config.js",
-            resources: "cpx ./src/resources/**/*.* ./dist"
+            resources: "cpx './src/resources/**/*.*' './dist'"
         },
         watch: {
             default: concurrent.nps("watch.resources", "watch.scripts", "test.watch"),


### PR DESCRIPTION
### simple bugfix in cpx build

---

### simulated bug after command:
```console
$ yarn start dev
```
![bug](https://user-images.githubusercontent.com/20017223/54967665-d45a9a00-4f56-11e9-97db-7daae363c6f6.png)


